### PR TITLE
Moving OpenAPI Generator's version to a stable one [FRESHPIPE-30862]

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,1 +1,1 @@
-FROM openapitools/openapi-generator-cli:v4.1.3
+FROM openapitools/openapi-generator-cli:v4.3.1

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,1 +1,1 @@
-FROM openapitools/openapi-generator-cli:latest
+FROM openapitools/openapi-generator-cli:v4.1.3

--- a/sdk/templates/ApiClient.mustache
+++ b/sdk/templates/ApiClient.mustache
@@ -467,6 +467,7 @@ class ApiClient {
         // Adding the default headers
         headers["vendorAccountId"] = this.vendorAccountId;
         headers["product"] = this.product;
+        headers[this.httpConstants.CONTENT_TYPE] = this.httpConstants.JSON;
 
         // apply authentications
         // this.applyAuthToRequest(request, authNames);


### PR DESCRIPTION
FreshRelease: [FRESHPIPE-30862](https://freshworks.freshrelease.com/ws/FRESHPIPE/tasks/FRESHPIPE-30862)

## Description:

- Changing the openapi-generator image version to the last stable version.

### Why this change?

- The latest version of the image does not concatenate the params for an API with `,` in the middle leading to syntax error during the build.
